### PR TITLE
feat: ✨ BDS full & incremental and ADS incremental support added

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,3 @@
 # These owners will be the default owners for everything in
 # the repo.
-* @ollionorg/datapipes-repo-admin @rishabh-cldcvr @jatinyadav-cc
+* @ollionorg/datapipes-repo-admin @rishabh-cldcvr @jatinyadav-cc @satyamcldcvr

--- a/airbyte-integrations/connectors/source-brightspace/metadata.yaml
+++ b/airbyte-integrations/connectors/source-brightspace/metadata.yaml
@@ -15,7 +15,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 694710ca-8933-4661-8db9-c38cb60411b0
-  dockerImageTag: 0.1.1
+  dockerImageTag: 0.1.2
   dockerRepository: datapipes-airbyte/source-brightspace
   githubIssueLabel: source-brightspace
   icon: brightspace.svg

--- a/airbyte-integrations/connectors/source-brightspace/metadata.yaml
+++ b/airbyte-integrations/connectors/source-brightspace/metadata.yaml
@@ -15,7 +15,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 694710ca-8933-4661-8db9-c38cb60411b0
-  dockerImageTag: 0.1.2
+  dockerImageTag: 0.2.0
   dockerRepository: datapipes-airbyte/source-brightspace
   githubIssueLabel: source-brightspace
   icon: brightspace.svg

--- a/airbyte-integrations/connectors/source-brightspace/source_brightspace/source.py
+++ b/airbyte-integrations/connectors/source-brightspace/source_brightspace/source.py
@@ -33,10 +33,10 @@ class SourceBrightspace(AbstractSource):
         self.test_connection(config)
         bs_client = self._get_bs_object(config)
         streams = []
-
-        list_bds = bs_client.get_list_of_bds_data_set()
-        for bds in list_bds:
-            streams.append(BDSStream(bs_client, bds))
+        if config.get('bds', {}).get('enable', False):
+            list_bds = bs_client.get_list_of_bds_data_set()
+            for bds in list_bds:
+                streams.append(BDSStream(bs_client, bds))
 
         stream_configs = {
             "final_grades": FinalGradesStream,

--- a/airbyte-integrations/connectors/source-brightspace/source_brightspace/source.py
+++ b/airbyte-integrations/connectors/source-brightspace/source_brightspace/source.py
@@ -31,6 +31,7 @@ class SourceBrightspace(AbstractSource):
 
     def streams(self, config: Mapping[str, Any]) -> List[Stream]:
         self.test_connection(config)
+        bs_client = self._get_bs_object(config)
         streams = []
         stream_configs = {
             "final_grades": FinalGradesStream,

--- a/airbyte-integrations/connectors/source-brightspace/source_brightspace/source.py
+++ b/airbyte-integrations/connectors/source-brightspace/source_brightspace/source.py
@@ -16,8 +16,7 @@ class SourceBrightspace(AbstractSource):
 
     def check_connection(self, logger: logging.Logger, config: Mapping[str, Any]) -> Tuple[bool, Optional[Any]]:
         try:
-            bs_client = self._get_bs_object(config)
-            bs_client.get_list_of_data_set()
+            self.test_connection(config)
         except HTTPError as error:
             if error.response.status_code == codes.UNAUTHORIZED:
                 error_res = json.loads(error.response.content) or {}
@@ -26,8 +25,12 @@ class SourceBrightspace(AbstractSource):
                 return False, f"{error.response.text}"
         return True, None
 
-    def streams(self, config: Mapping[str, Any]) -> List[Stream]:
+    def test_connection(self, config):
         bs_client = self._get_bs_object(config)
+        bs_client.get_list_of_data_set()
+
+    def streams(self, config: Mapping[str, Any]) -> List[Stream]:
+        self.test_connection(config)
         streams = []
         stream_configs = {
             "final_grades": FinalGradesStream,

--- a/airbyte-integrations/connectors/source-brightspace/source_brightspace/source.py
+++ b/airbyte-integrations/connectors/source-brightspace/source_brightspace/source.py
@@ -27,12 +27,17 @@ class SourceBrightspace(AbstractSource):
 
     def test_connection(self, config):
         bs_client = self._get_bs_object(config)
-        bs_client.get_list_of_data_set()
+        bs_client.get_list_of_ads_data_set()
 
     def streams(self, config: Mapping[str, Any]) -> List[Stream]:
         self.test_connection(config)
         bs_client = self._get_bs_object(config)
         streams = []
+
+        list_bds = bs_client.get_list_of_bds_data_set()
+        for bds in list_bds:
+            streams.append(BDSStream(bs_client, bds))
+
         stream_configs = {
             "final_grades": FinalGradesStream,
             "enrollments_and_withdrawals": EnrollmentsAndWithdrawalsStream,

--- a/airbyte-integrations/connectors/source-brightspace/source_brightspace/streams.py
+++ b/airbyte-integrations/connectors/source-brightspace/source_brightspace/streams.py
@@ -62,7 +62,7 @@ class ADSStream(BrightspaceStream, ABC):
         return "last_modified"
 
     @abstractmethod
-    def create_export_job(self, sync_mode: SyncMode) -> BSExportJob:
+    def create_export_job(self) -> BSExportJob:
         pass
 
     def read_records(
@@ -282,7 +282,7 @@ class LearnerUsageStream(ADSStream, ABC):
                 },
                 {
                     "name": "roles",
-                    "value": self.roles
+                    "value": ",".join(map(str, self.roles))
                 }
             ]
         }
@@ -317,7 +317,7 @@ class CLOEStream(ADSStream, ABC):
                 },
                 {
                     "name": "roles",
-                    "value": self.roles
+                    "value": ",".join(map(str, self.roles))
                 }
             ]
         }
@@ -373,7 +373,7 @@ class InstructorUsageStream(ADSStream, ABC):
                 },
                 {
                     "name": "roles",
-                    "value": self.roles
+                    "value": ",".join(map(str, self.roles))
                 }
             ]
         }
@@ -535,7 +535,7 @@ class ContentProgressStream(ADSStream, ABC):
                 },
                 {
                     "name": "roles",
-                    "value": self.roles
+                    "value": ",".join(map(str, self.roles))
                 }
             ]
         }
@@ -578,7 +578,7 @@ class SurveyResultsStream(ADSStream, ABC):
                 },
                 {
                     "name": "roles",
-                    "value": self.roles
+                    "value": ",".join(map(str, self.roles))
                 }
             ]
         }
@@ -659,7 +659,7 @@ class AttendanceStream(ADSStream, ABC):
                 },
                 {
                     "name": "roles",
-                    "value": self.roles
+                    "value": ",".join(map(str, self.roles))
                 }
             ]
         }

--- a/airbyte-integrations/connectors/source-brightspace/source_brightspace/streams.py
+++ b/airbyte-integrations/connectors/source-brightspace/source_brightspace/streams.py
@@ -293,7 +293,7 @@ class CLOEStream(ADSStream, ABC):
     def __init__(
             self, org_unit_id: str, roles: str, **kwargs
     ):
-        super().__init__(**kwargs)
+        super().__init__(start_date="", **kwargs)
         self.org_unit_id = org_unit_id
         self.roles = roles
 
@@ -470,7 +470,7 @@ class ProgrammeLearningOutcomeEvaluationStream(ADSStream, ABC):
 
     @property
     def name(self) -> str:
-        return "Programme Learning Outcome Evaluation"
+        return "Programme Level Outcome Evaluation"
 
     def create_export_job(self) -> BSExportJob:
         data_sets = self.bs_api.get_list_of_ads_data_set()

--- a/airbyte-integrations/connectors/source-brightspace/source_brightspace/streams.py
+++ b/airbyte-integrations/connectors/source-brightspace/source_brightspace/streams.py
@@ -3,19 +3,48 @@ import math
 import time
 import zipfile
 from abc import ABC, abstractmethod
-from typing import Mapping, Optional, Any, Iterable, Union, List, Tuple
+from datetime import datetime
+from functools import lru_cache
+from typing import Mapping, Optional, Any, Iterable, Union, List, Tuple, MutableMapping
 
 import pandas as pd
 import pendulum
 from airbyte_cdk.sources.streams import Stream
 from airbyte_protocol.models import SyncMode
 from numpy import nan
+from pandas.api.types import is_datetime64_any_dtype as is_datetime
+from pandas.api.types import is_timedelta64_dtype as is_timedelta
 from pendulum import DateTime
 
-from source_brightspace.api import BrightspaceClient, BSExportJob, ExportJobStatus
+from source_brightspace.api import BrightspaceClient, BSExportJob, ExportJobStatus, BrightspaceDataSetInfo, BdsType
 
 
-class ADSStream(Stream, ABC):
+class BrightspaceStream(Stream, ABC):
+
+    @property
+    def availability_strategy(self) -> Optional["AvailabilityStrategy"]:
+        return None
+
+    def read_with_chunks(self, response_content, chunk_size: int = 100) -> Iterable[Tuple[int, Mapping[str, Any]]]:
+        try:
+            with io.BytesIO(response_content) as response_stream:
+                with zipfile.ZipFile(response_stream) as zipped_data_set:
+                    files = zipped_data_set.namelist()
+                    csv_name = files[0]
+
+                    with zipped_data_set.open(csv_name) as csv_file:
+                        chunks = pd.read_csv(csv_file, chunksize=chunk_size, iterator=True, dialect="unix", dtype=object)
+                        for chunk in chunks:
+                            chunk = chunk.replace({nan: None}).to_dict(orient="records")
+                            for row in chunk:
+                                # print(row)
+                                yield row
+        except pd.errors.EmptyDataError as e:
+            self.logger.info(f"Empty data received. {e}")
+            yield from []
+
+
+class ADSStream(BrightspaceStream, ABC):
     DEFAULT_WAIT_TIMEOUT_SECONDS = 60 * 60 * 12  # 12-hour job running time
     MAX_CHECK_INTERVAL_SECONDS = 2.0
     MAX_RETRY_NUMBER = 3  # maximum number of retries for creating successful jobs
@@ -27,12 +56,8 @@ class ADSStream(Stream, ABC):
         self.bs_api = bs_api
 
     @abstractmethod
-    def create_export_job(self) -> BSExportJob:
+    def create_export_job(self, sync_mode: SyncMode) -> BSExportJob:
         pass
-
-    @property
-    def availability_strategy(self) -> Optional["AvailabilityStrategy"]:
-        return None
 
     def read_records(
             self,
@@ -92,24 +117,6 @@ class ADSStream(Stream, ABC):
         self.logger.warning(f"Not wait the {self.name} data for {self.DEFAULT_WAIT_TIMEOUT_SECONDS} seconds, data: {job_info}!!")
         return job_status
 
-    def read_with_chunks(self, response_content, chunk_size: int = 100) -> Iterable[Tuple[int, Mapping[str, Any]]]:
-        try:
-            with io.BytesIO(response_content) as response_stream:
-                with zipfile.ZipFile(response_stream) as zipped_data_set:
-                    files = zipped_data_set.namelist()
-                    csv_name = files[0]
-
-                    with zipped_data_set.open(csv_name) as csv_file:
-                        chunks = pd.read_csv(csv_file, chunksize=chunk_size, iterator=True, dialect="unix", dtype=object)
-                        for chunk in chunks:
-                            chunk = chunk.replace({nan: None}).to_dict(orient="records")
-                            for row in chunk:
-                                # print(row)
-                                yield row
-        except pd.errors.EmptyDataError as e:
-            self.logger.info(f"Empty data received. {e}")
-            yield from []
-
 
 class FinalGradesStream(ADSStream, ABC):
 
@@ -129,7 +136,7 @@ class FinalGradesStream(ADSStream, ABC):
         return "Final Grades"
 
     def create_export_job(self) -> BSExportJob:
-        data_sets = self.bs_api.get_list_of_data_set()
+        data_sets = self.bs_api.get_list_of_ads_data_set()
         data_set = next(filter(lambda x: x.name == self.name, data_sets), None)
         payload = {
             "DataSetId": data_set.data_set_id,
@@ -166,7 +173,7 @@ class EnrollmentsAndWithdrawalsStream(ADSStream, ABC):
         return "Enrolments and Withdrawals"
 
     def create_export_job(self) -> BSExportJob:
-        data_sets = self.bs_api.get_list_of_data_set()
+        data_sets = self.bs_api.get_list_of_ads_data_set()
         data_set = next(filter(lambda x: x.name == self.name, data_sets), None)
         payload = {
             "DataSetId": data_set.data_set_id,
@@ -206,7 +213,7 @@ class AllGradesStream(ADSStream, ABC):
         return "All Grades"
 
     def create_export_job(self) -> BSExportJob:
-        data_sets = self.bs_api.get_list_of_data_set()
+        data_sets = self.bs_api.get_list_of_ads_data_set()
         data_set = next(filter(lambda x: x.name == self.name, data_sets), None)
         payload = {
             "DataSetId": data_set.data_set_id,
@@ -247,7 +254,7 @@ class LearnerUsageStream(ADSStream, ABC):
         return "Learner Usage"
 
     def create_export_job(self) -> BSExportJob:
-        data_sets = self.bs_api.get_list_of_data_set()
+        data_sets = self.bs_api.get_list_of_ads_data_set()
         data_set = next(filter(lambda x: x.name == self.name, data_sets), None)
         payload = {
             "DataSetId": data_set.data_set_id,
@@ -290,7 +297,7 @@ class CLOEStream(ADSStream, ABC):
         return "CLOE"
 
     def create_export_job(self) -> BSExportJob:
-        data_sets = self.bs_api.get_list_of_data_set()
+        data_sets = self.bs_api.get_list_of_ads_data_set()
         data_set = next(filter(lambda x: x.name == self.name, data_sets), None)
         payload = {
             "DataSetId": data_set.data_set_id,
@@ -327,7 +334,7 @@ class InstructorUsageStream(ADSStream, ABC):
         return "Instructor Usage"
 
     def create_export_job(self) -> BSExportJob:
-        data_sets = self.bs_api.get_list_of_data_set()
+        data_sets = self.bs_api.get_list_of_ads_data_set()
         data_set = next(filter(lambda x: x.name == self.name, data_sets), None)
         payload = {
             "DataSetId": data_set.data_set_id,
@@ -371,7 +378,7 @@ class AwardsIssuedStream(ADSStream, ABC):
         return "Awards Issued"
 
     def create_export_job(self) -> BSExportJob:
-        data_sets = self.bs_api.get_list_of_data_set()
+        data_sets = self.bs_api.get_list_of_ads_data_set()
         data_set = next(filter(lambda x: x.name == self.name, data_sets), None)
         payload = {
             "DataSetId": data_set.data_set_id,
@@ -411,7 +418,7 @@ class RubricAssessmentsStream(ADSStream, ABC):
         return "Rubric Assessments"
 
     def create_export_job(self) -> BSExportJob:
-        data_sets = self.bs_api.get_list_of_data_set()
+        data_sets = self.bs_api.get_list_of_ads_data_set()
         data_set = next(filter(lambda x: x.name == self.name, data_sets), None)
         payload = {
             "DataSetId": data_set.data_set_id,
@@ -452,7 +459,7 @@ class ProgrammeLearningOutcomeEvaluationStream(ADSStream, ABC):
         return "Programme Learning Outcome Evaluation"
 
     def create_export_job(self) -> BSExportJob:
-        data_sets = self.bs_api.get_list_of_data_set()
+        data_sets = self.bs_api.get_list_of_ads_data_set()
         data_set = next(filter(lambda x: x.name == self.name, data_sets), None)
         payload = {
             "DataSetId": data_set.data_set_id,
@@ -497,7 +504,7 @@ class ContentProgressStream(ADSStream, ABC):
         return "Content Progress"
 
     def create_export_job(self) -> BSExportJob:
-        data_sets = self.bs_api.get_list_of_data_set()
+        data_sets = self.bs_api.get_list_of_ads_data_set()
         data_set = next(filter(lambda x: x.name == self.name, data_sets), None)
         payload = {
             "DataSetId": data_set.data_set_id,
@@ -542,7 +549,7 @@ class SurveyResultsStream(ADSStream, ABC):
         return "Survey Results"
 
     def create_export_job(self) -> BSExportJob:
-        data_sets = self.bs_api.get_list_of_data_set()
+        data_sets = self.bs_api.get_list_of_ads_data_set()
         data_set = next(filter(lambda x: x.name == self.name, data_sets), None)
         payload = {
             "DataSetId": data_set.data_set_id,
@@ -586,7 +593,7 @@ class CourseOfferingEnrollmentsStream(ADSStream, ABC):
         return "Course Offering Enrolments"
 
     def create_export_job(self) -> BSExportJob:
-        data_sets = self.bs_api.get_list_of_data_set()
+        data_sets = self.bs_api.get_list_of_ads_data_set()
         data_set = next(filter(lambda x: x.name == self.name, data_sets), None)
         payload = {
             "DataSetId": data_set.data_set_id,
@@ -627,7 +634,7 @@ class AttendanceStream(ADSStream, ABC):
         return "Attendance"
 
     def create_export_job(self) -> BSExportJob:
-        data_sets = self.bs_api.get_list_of_data_set()
+        data_sets = self.bs_api.get_list_of_ads_data_set()
         data_set = next(filter(lambda x: x.name == self.name, data_sets), None)
         payload = {
             "DataSetId": data_set.data_set_id,
@@ -651,3 +658,172 @@ class AttendanceStream(ADSStream, ABC):
             ]
         }
         return self.bs_api.create_export_job(payload=payload)
+
+
+class BDSStream(BrightspaceStream, ABC):
+
+    def __init__(
+            self, bs_api: BrightspaceClient, bds: BrightspaceDataSetInfo, **kwargs
+    ):
+        super().__init__(**kwargs)
+        self.bs_api = bs_api
+        self.bds_info = bds
+
+    @property
+    def name(self) -> str:
+        return self.bds_info.full.name
+
+    #
+    # @property
+    # def cursor_field(self) -> str:
+    #     return "last_modified"
+
+    @property
+    def primary_key(self) -> Optional[Union[str, List[str], List[List[str]]]]:
+        return ""
+
+    @lru_cache(maxsize=None)
+    def get_json_schema(self) -> Mapping[str, Any]:
+        extracts = self.bs_api.get_bds_extracts(
+            schema_id=self.bds_info.schema_id,
+            plugin_id=self.bds_info.full.plugin_id
+        )
+        full_extract = next(filter(lambda extract: extract.bds_type == BdsType.Full, extracts), None)
+        bds_http_stream = self.bs_api.download_bds_extracts(full_extract.download_link)
+        try:
+            self.logger.info(f"Fetching schema started for bds {self.name} ................")
+            fields = {}
+            for df in self.read_csv_files(http_stream=bds_http_stream, sample_read=True):
+                for col in df.columns:
+                    if df[col].isnull().values.all():
+                        if not fields.get(col):
+                            fields[col] = {"type": None}
+                        continue
+                    # if data type of the same column differs in dataframes, we choose the broadest one
+                    prev_frame_column_type = fields.get(col, {}).get("type")
+                    fields[col] = {"type": self.dtype_to_json_type(prev_frame_column_type, df[col].dtype),
+                                   "dtype": df[col].dtype}
+
+                    if is_timedelta(df[col]):
+                        fields[col]["format"] = "date-time"
+                        fields[col]["airbyte_type"] = "timestamp_with_timezone"
+                    elif is_datetime(df[col]):
+                        fields[col]["format"] = "date-time"
+            schema = {}
+            for field in fields:
+                schema[field] = {"type": [fields[field]["type"] if fields[field]["type"] else "string", "null"]}
+                if "format" in fields[field]:
+                    schema[field]["format"] = fields[field]["format"]
+
+            self.logger.info(f"Fetching schema completed for bds {self.name}.")
+            return {
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "type": "object",
+                "properties": schema
+            }
+
+        except pd.errors.EmptyDataError as e:
+            self.logger.error(f"Empty data received. {e}")
+
+    def read_csv_files(self, http_stream,
+                       chunk_size: int = 1000,
+                       sample_read: bool = False,
+                       sample_read_count: int = 1000):
+        with io.BytesIO(http_stream) as response_stream:
+            with zipfile.ZipFile(response_stream) as zipped_data_set:
+                files = zipped_data_set.namelist()
+                if not files:
+                    return
+                csv_name = files[0]
+                with zipped_data_set.open(csv_name) as csv_file:
+                    chunks = pd.read_csv(csv_file, chunksize=chunk_size)
+                    record_count = 0
+                    for df in chunks:
+                        yield df
+                        record_count += len(df)
+                        if sample_read and record_count >= sample_read_count:
+                            break
+
+    @staticmethod
+    def dtype_to_json_type(current_type: str, dtype) -> str:
+        """Convert Pandas Dataframe types to Airbyte Types.
+
+        :param current_type: str - one of the following types based on previous dataframes
+        :param dtype: Pandas Dataframe type
+        :return: Corresponding Airbyte Type
+        """
+        number_types = ("double", "float64")
+        integer_types = ("int32", "int64", "int96")
+        if current_type == "string":
+            # previous column values was of the string type, no sense to look further
+            return current_type
+        if dtype == object:
+            return "string"
+        if str(dtype).lower() in number_types:
+            return "number"
+        if str(dtype).lower() in integer_types:
+            return "integer" if not current_type else current_type
+        if str(dtype).lower() == "bool" and (not current_type or current_type == "boolean"):
+            return "boolean"
+        if dtype == "datetime64[ns]":
+            return "date-time"
+        return "string"
+
+    def read_records(
+            self,
+            sync_mode: SyncMode,
+            cursor_field: List[str] = None,
+            stream_slice: Mapping[str, Any] = None,
+            stream_state: Mapping[str, Any] = None,
+    ) -> Iterable[Mapping[str, Any]]:
+
+        if sync_mode == SyncMode.full_refresh:
+            for record in self._full_read():
+                yield record
+        elif sync_mode == SyncMode.incremental:
+            for record in self._incremental_read(stream_state):
+                yield record
+
+    def _full_read(self):
+        extracts = self.bs_api.get_bds_extracts(
+            schema_id=self.bds_info.schema_id,
+            plugin_id=self.bds_info.full.plugin_id
+        )
+        full_extract = next(filter(lambda extract: extract.bds_type == BdsType.Full, extracts), None)
+        if not full_extract.download_link:
+            return
+        extracted_stream = self.bs_api.download_bds_extracts(full_extract.download_link)
+        for record in self.read_with_chunks(extracted_stream):
+            record["stream_last_sync_time"] = full_extract.to_state
+            yield record
+
+    def _incremental_read(self, stream_state):
+        last_modified_str = stream_state.get('last_modified') if stream_state else None
+        if not last_modified_str:
+            yield from self._full_read()
+            return
+
+        extracts = self.bs_api.get_bds_extracts(
+            schema_id=self.bds_info.schema_id,
+            plugin_id=self.bds_info.differential.plugin_id
+        )
+        # Convert last_modified string to datetime object
+        last_modified = datetime.fromisoformat(last_modified_str.replace('Z', '+00:00'))
+
+        # Using a lambda function to filter extracts based on the datetime comparison and then sort them
+        filtered_extracts = filter(lambda extract: extract.bds_type == BdsType.Differential and extract.created_date > last_modified,
+                                   extracts)
+        sorted_extracts = sorted(filtered_extracts, key=lambda extract: extract.created_date)
+
+        for extracted in sorted_extracts:
+            if not extracted.download_link:
+                continue
+            extracted_stream = self.bs_api.download_bds_extracts(extracted.download_link)
+            for record in self.read_with_chunks(extracted_stream):
+                record["stream_last_sync_time"] = extracted.to_state
+                yield record
+
+    def get_updated_state(
+            self, current_stream_state: MutableMapping[str, Any], latest_record: Mapping[str, Any]
+    ) -> MutableMapping[str, Any]:
+        return {"last_modified": latest_record["stream_last_sync_time"]}


### PR DESCRIPTION
<!--
Thanks for your contribution! 
Before you submit the pull request, 
I'd like to kindly remind you to take a moment and read through our guidelines
to ensure that your contribution aligns with the type of contributions our project accepts.
All the information you need can be found here:
   https://docs.airbyte.com/contributing-to-airbyte/

We truly appreciate your interest in contributing to Airbyte,
and we're excited to see what you have to offer! 

If you have any questions or need any assistance, feel free to reach out in #contributions Slack channel.
-->

## What
*Describe what the change is solving*
*It helps to add screenshots if it affects the frontend.*

## How
*Describe the solution*

## Recommended reading order
1. `x.java`
2. `y.python`

## 🚨 User Impact 🚨
*Are there any breaking changes? What is the end result perceived by the user?*

*For connector PRs, use this section to explain which type of semantic versioning bump occurs as a result of the changes. Refer to our [Semantic Versioning for Connectors](https://docs.airbyte.com/contributing-to-airbyte/#semantic-versioning-for-connectors) guidelines for more information. **Breaking changes to connectors must be documented by an Airbyte engineer (PR author, or reviewer for community PRs) by using the [Breaking Change Release Playbook](https://docs.google.com/document/d/1VYQggHbL_PN0dDDu7rCyzBLGRtX-R3cpwXaY8QxEgzw/edit).***

*If there are breaking changes, please merge this PR with the 🚨🚨 emoji so changelog authors can further highlight this if needed.*


## Pre-merge Actions
*Expand the relevant checklist and delete the others.*

<details><summary><strong>New Connector</strong></summary>

### Community member or Airbyter

- **Community member?** Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- Connector version is set to `0.0.1`
    - `Dockerfile` has version `0.0.1`
- Documentation updated
    - Connector's `README.md`
    - Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - `docs/integrations/<source or destination>/<name>.md` including changelog with an entry for the initial version. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
    - `docs/integrations/README.md`

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- Create a non-forked branch based on this PR and test the below items on it
- Build is successful
- If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).

</details>

<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- Unit & integration tests added


### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- Create a non-forked branch based on this PR and test the below items on it
- Build is successful
- If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).

</details>

<details><summary><strong>Connector Generator</strong></summary>

- Issue acceptance criteria met
- PR name follows [PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/resources/pull-requests-handbook)
- If adding a new generator, add it to the [list of scaffold modules being tested](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connector-templates/generator/build.gradle#L41)
- The generator test modules (all connectors with `-scaffold` in their name) have been updated with the latest scaffold by running `./gradlew :airbyte-integrations:connector-templates:generator:generateScaffolds` then checking in your changes
- Documentation which references the generator is updated as needed

</details>

<details><summary><strong>Updating the Python CDK</strong></summary>

### Airbyter

Before merging:
- Pull Request description explains what problem it is solving
- Code change is unit tested
- Build and my-py check pass
- Smoke test the change on at least one affected connector
   - On Github: Run [this workflow](https://github.com/airbytehq/airbyte/actions/workflows/connectors_tests.yml), passing `--use-local-cdk --name=source-<connector>` as options
   - Locally: `airbyte-ci connectors --use-local-cdk --name=source-<connector> test`
- PR is reviewed and approved
      
After merging:
- [Publish the CDK](https://github.com/airbytehq/airbyte/actions/workflows/publish-cdk-command-manually.yml)
   - The CDK does not follow proper semantic versioning. Choose minor if this the change has significant user impact or is a breaking change. Choose patch otherwise.
   - Write a thoughtful changelog message so we know what was updated.
- Merge the platform PR that was auto-created for updating the Connector Builder's CDK version
   - This step is optional if the change does not affect the connector builder or declarative connectors.

</details>
