### PR TITLE
fix: DPA-2740 Oracle data type issue for integer in custom SQL

### DIFF
--- a/airbyte-cdk/java/airbyte-cdk/db-sources/src/main/java/io/airbyte/cdk/integrations/source/jdbc/AbstractJdbcSource.java
+++ b/airbyte-cdk/java/airbyte-cdk/db-sources/src/main/java/io/airbyte/cdk/integrations/source/jdbc/AbstractJdbcSource.java
@@ -91,7 +91,8 @@ import org.slf4j.LoggerFactory;
  * relational DB source which can be accessed via JDBC driver. If you are implementing a connector
  * for a relational DB which has a JDBC driver, make an effort to use this class.
  */
-public abstract class AbstractJdbcSource<Datatype> extends AbstractDbSource<Datatype, JdbcDatabase> implements Source {
+public abstract class AbstractJdbcSource<Datatype> extends
+    AbstractDbSource<Datatype, JdbcDatabase> implements Source {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(AbstractJdbcSource.class);
 
@@ -102,8 +103,8 @@ public abstract class AbstractJdbcSource<Datatype> extends AbstractDbSource<Data
   protected Collection<DataSource> dataSources = new ArrayList<>();
 
   public AbstractJdbcSource(final String driverClass,
-                            final Supplier<JdbcStreamingQueryConfig> streamingQueryConfigProvider,
-                            final JdbcCompatibleSourceOperations<Datatype> sourceOperations) {
+      final Supplier<JdbcStreamingQueryConfig> streamingQueryConfigProvider,
+      final JdbcCompatibleSourceOperations<Datatype> sourceOperations) {
     super(driverClass);
     this.streamingQueryConfigProvider = streamingQueryConfigProvider;
     this.sourceOperations = sourceOperations;
@@ -125,14 +126,15 @@ public abstract class AbstractJdbcSource<Datatype> extends AbstractDbSource<Data
     if (syncMode.equals(SyncMode.INCREMENTAL) && getStateEmissionFrequency() > 0) {
       final String quotedCursorField = enquoteIdentifier(cursorField.get(), getQuoteString());
       String query = "";
-      if (!whereClause.equals("")) {
+      if (!whereClause.isEmpty()) {
         query = String.format("SELECT %s FROM %s where %s ORDER BY %s ASC",
             enquoteIdentifierList(columnNames, getQuoteString()),
             getFullyQualifiedTableNameWithQuoting(schemaName, tableName, getQuoteString()),
             whereClause,
             quotedCursorField);
-      } else if (customSQL != null && !customSQL.equals("")) {
-        query = String.format("SELECT * FROM (%s) sc ORDER BY %s ASC", customSQL, quotedCursorField);
+      } else if (customSQL != null && !customSQL.isEmpty()) {
+        query = String.format("SELECT * FROM (%s) sc ORDER BY %s ASC", customSQL,
+            quotedCursorField);
       } else {
         query = String.format("SELECT %s FROM %s ORDER BY %s ASC",
             enquoteIdentifierList(columnNames, getQuoteString()),
@@ -169,10 +171,12 @@ public abstract class AbstractJdbcSource<Datatype> extends AbstractDbSource<Data
    * @return list of consumers that run queries for the check command.
    */
   @Trace(operationName = CHECK_TRACE_OPERATION_NAME)
-  protected List<CheckedConsumer<JdbcDatabase, Exception>> getCheckOperations(final JsonNode config) throws Exception {
+  protected List<CheckedConsumer<JdbcDatabase, Exception>> getCheckOperations(final JsonNode config)
+      throws Exception {
     return ImmutableList.of(database -> {
       LOGGER.info("Attempting to get metadata from the database to see if we can connect.");
-      database.bufferedResultSetQuery(connection -> connection.getMetaData().getCatalogs(), sourceOperations::rowToJson);
+      database.bufferedResultSetQuery(connection -> connection.getMetaData().getCatalogs(),
+          sourceOperations::rowToJson);
     });
   }
 
@@ -182,36 +186,42 @@ public abstract class AbstractJdbcSource<Datatype> extends AbstractDbSource<Data
    * @return a map by StreamName to associated list of primary keys
    */
   @VisibleForTesting
-  public static Map<String, List<String>> aggregatePrimateKeys(final List<PrimaryKeyAttributesFromDb> entries) {
+  public static Map<String, List<String>> aggregatePrimateKeys(
+      final List<PrimaryKeyAttributesFromDb> entries) {
     final Map<String, List<String>> result = new HashMap<>();
-    entries.stream().sorted(Comparator.comparingInt(PrimaryKeyAttributesFromDb::keySequence)).forEach(entry -> {
-      if (!result.containsKey(entry.streamName())) {
-        result.put(entry.streamName(), new ArrayList<>());
-      }
-      result.get(entry.streamName()).add(entry.primaryKey());
-    });
+    entries.stream().sorted(Comparator.comparingInt(PrimaryKeyAttributesFromDb::keySequence))
+        .forEach(entry -> {
+          if (!result.containsKey(entry.streamName())) {
+            result.put(entry.streamName(), new ArrayList<>());
+          }
+          result.get(entry.streamName()).add(entry.primaryKey());
+        });
     return result;
   }
 
   private String getCatalog(final SqlDatabase database) {
-    return (database.getSourceConfig().has(JdbcUtils.DATABASE_KEY) ? database.getSourceConfig().get(JdbcUtils.DATABASE_KEY).asText() : null);
+    return (database.getSourceConfig().has(JdbcUtils.DATABASE_KEY) ? database.getSourceConfig()
+        .get(JdbcUtils.DATABASE_KEY).asText() : null);
   }
 
   @Override
-  protected List<TableInfo<CommonField<Datatype>>> discoverInternal(final JdbcDatabase database, final String schema) throws Exception {
+  protected List<TableInfo<CommonField<Datatype>>> discoverInternal(final JdbcDatabase database,
+      final String schema) throws Exception {
     final Set<String> internalSchemas = new HashSet<>(getExcludedInternalNameSpaces());
     LOGGER.info("Internal schemas to exclude: {}", internalSchemas);
-    final Set<JdbcPrivilegeDto> tablesWithSelectGrantPrivilege = getPrivilegesTableForCurrentUser(database, schema);
+    final Set<JdbcPrivilegeDto> tablesWithSelectGrantPrivilege = getPrivilegesTableForCurrentUser(
+        database, schema);
     return database.bufferedResultSetQuery(
-        // retrieve column metadata from the database
-        connection -> connection.getMetaData().getColumns(getCatalog(database), schema, null, null),
-        // store essential column metadata to a Json object from the result set about each column
-        this::getColumnMetadata)
+            // retrieve column metadata from the database
+            connection -> connection.getMetaData().getColumns(getCatalog(database), schema, null, null),
+            // store essential column metadata to a Json object from the result set about each column
+            this::getColumnMetadata)
         .stream()
         .filter(excludeNotAccessibleTables(internalSchemas, tablesWithSelectGrantPrivilege))
         // group by schema and table name to handle the case where a table with the same name exists in
         // multiple schemas.
-        .collect(Collectors.groupingBy(t -> ImmutablePair.of(t.get(INTERNAL_SCHEMA_NAME).asText(), t.get(INTERNAL_TABLE_NAME).asText())))
+        .collect(Collectors.groupingBy(t -> ImmutablePair.of(t.get(INTERNAL_SCHEMA_NAME).asText(),
+            t.get(INTERNAL_TABLE_NAME).asText())))
         .values()
         .stream()
         .map(fields -> TableInfo.<CommonField<Datatype>>builder()
@@ -229,7 +239,8 @@ public abstract class AbstractJdbcSource<Datatype> extends AbstractDbSource<Data
                       f.get(INTERNAL_COLUMN_SIZE).asInt(),
                       f.get(INTERNAL_IS_NULLABLE).asBoolean(),
                       jsonType);
-                  return new CommonField<Datatype>(f.get(INTERNAL_COLUMN_NAME).asText(), datatype) {};
+                  return new CommonField<Datatype>(f.get(INTERNAL_COLUMN_NAME).asText(), datatype) {
+                  };
                 })
                 .collect(Collectors.toList()))
             .cursorFields(extractCursorFields(fields))
@@ -245,7 +256,7 @@ public abstract class AbstractJdbcSource<Datatype> extends AbstractDbSource<Data
   }
 
   protected Predicate<JsonNode> excludeNotAccessibleTables(final Set<String> internalSchemas,
-                                                           final Set<JdbcPrivilegeDto> tablesWithSelectGrantPrivilege) {
+      final Set<JdbcPrivilegeDto> tablesWithSelectGrantPrivilege) {
     return jsonNode -> {
       if (tablesWithSelectGrantPrivilege.isEmpty()) {
         return isNotInternalSchema(jsonNode, internalSchemas);
@@ -253,26 +264,29 @@ public abstract class AbstractJdbcSource<Datatype> extends AbstractDbSource<Data
       return tablesWithSelectGrantPrivilege.stream()
           .anyMatch(e -> e.getSchemaName().equals(jsonNode.get(INTERNAL_SCHEMA_NAME).asText()))
           && tablesWithSelectGrantPrivilege.stream()
-              .anyMatch(e -> e.getTableName().equals(jsonNode.get(INTERNAL_TABLE_NAME).asText()))
+          .anyMatch(e -> e.getTableName().equals(jsonNode.get(INTERNAL_TABLE_NAME).asText()))
           && !internalSchemas.contains(jsonNode.get(INTERNAL_SCHEMA_NAME).asText());
     };
   }
 
   // needs to override isNotInternalSchema for connectors that override
   // getPrivilegesTableForCurrentUser()
-  protected boolean isNotInternalSchema(final JsonNode jsonNode, final Set<String> internalSchemas) {
+  protected boolean isNotInternalSchema(final JsonNode jsonNode,
+      final Set<String> internalSchemas) {
     return !internalSchemas.contains(jsonNode.get(INTERNAL_SCHEMA_NAME).asText());
   }
 
   /**
    * @param resultSet Description of a column available in the table catalog.
-   * @return Essential information about a column to determine which table it belongs to and its type.
+   * @return Essential information about a column to determine which table it belongs to and its
+   * type.
    */
   private JsonNode getColumnMetadata(final ResultSet resultSet) throws SQLException {
     final var fieldMap = ImmutableMap.<String, Object>builder()
         // we always want a namespace, if we cannot get a schema, use db name.
         .put(INTERNAL_SCHEMA_NAME,
-            resultSet.getObject(JDBC_COLUMN_SCHEMA_NAME) != null ? resultSet.getString(JDBC_COLUMN_SCHEMA_NAME)
+            resultSet.getObject(JDBC_COLUMN_SCHEMA_NAME) != null ? resultSet.getString(
+                JDBC_COLUMN_SCHEMA_NAME)
                 : resultSet.getObject(JDBC_COLUMN_DATABASE_NAME))
         .put(INTERNAL_TABLE_NAME, resultSet.getString(JDBC_COLUMN_TABLE_NAME))
         .put(INTERNAL_COLUMN_NAME, resultSet.getString(JDBC_COLUMN_COLUMN_NAME))
@@ -306,40 +320,53 @@ public abstract class AbstractJdbcSource<Datatype> extends AbstractDbSource<Data
 
   @Override
   protected Map<String, List<String>> discoverPrimaryKeys(final JdbcDatabase database,
-                                                          final List<TableInfo<CommonField<Datatype>>> tableInfos) {
-    LOGGER.info("Discover primary keys for tables: " + tableInfos.stream().map(TableInfo::getName).collect(
-        Collectors.toSet()));
+      final List<TableInfo<CommonField<Datatype>>> tableInfos) {
+    LOGGER.info(
+        "Discover primary keys for tables: " + tableInfos.stream().map(TableInfo::getName).collect(
+            Collectors.toSet()));
     try {
       // Get all primary keys without specifying a table name
-      final Map<String, List<String>> tablePrimaryKeys = aggregatePrimateKeys(database.bufferedResultSetQuery(
-          connection -> connection.getMetaData().getPrimaryKeys(getCatalog(database), null, null),
-          r -> {
-            final String schemaName =
-                r.getObject(JDBC_COLUMN_SCHEMA_NAME) != null ? r.getString(JDBC_COLUMN_SCHEMA_NAME) : r.getString(JDBC_COLUMN_DATABASE_NAME);
-            final String streamName = JdbcUtils.getFullyQualifiedTableName(schemaName, r.getString(JDBC_COLUMN_TABLE_NAME));
-            final String primaryKey = r.getString(JDBC_COLUMN_COLUMN_NAME);
-            final int keySeq = r.getInt(KEY_SEQ);
-            return new PrimaryKeyAttributesFromDb(streamName, primaryKey, keySeq);
-          }));
+      final Map<String, List<String>> tablePrimaryKeys = aggregatePrimateKeys(
+          database.bufferedResultSetQuery(
+              connection -> connection.getMetaData()
+                  .getPrimaryKeys(getCatalog(database), null, null),
+              r -> {
+                final String schemaName =
+                    r.getObject(JDBC_COLUMN_SCHEMA_NAME) != null ? r.getString(
+                        JDBC_COLUMN_SCHEMA_NAME) : r.getString(JDBC_COLUMN_DATABASE_NAME);
+                final String streamName = JdbcUtils.getFullyQualifiedTableName(schemaName,
+                    r.getString(JDBC_COLUMN_TABLE_NAME));
+                final String primaryKey = r.getString(JDBC_COLUMN_COLUMN_NAME);
+                final int keySeq = r.getInt(KEY_SEQ);
+                return new PrimaryKeyAttributesFromDb(streamName, primaryKey, keySeq);
+              }));
       if (!tablePrimaryKeys.isEmpty()) {
         return tablePrimaryKeys;
       }
     } catch (final SQLException e) {
-      LOGGER.debug(String.format("Could not retrieve primary keys without a table name (%s), retrying", e));
+      LOGGER.debug(
+          String.format("Could not retrieve primary keys without a table name (%s), retrying", e));
     }
     // Get primary keys one table at a time
     return tableInfos.stream()
         .collect(Collectors.toMap(
-            tableInfo -> JdbcUtils.getFullyQualifiedTableName(tableInfo.getNameSpace(), tableInfo.getName()),
+            tableInfo -> JdbcUtils.getFullyQualifiedTableName(tableInfo.getNameSpace(),
+                tableInfo.getName()),
             tableInfo -> {
-              final String streamName = JdbcUtils.getFullyQualifiedTableName(tableInfo.getNameSpace(), tableInfo.getName());
+              final String streamName = JdbcUtils.getFullyQualifiedTableName(
+                  tableInfo.getNameSpace(), tableInfo.getName());
               try {
-                final Map<String, List<String>> primaryKeys = aggregatePrimateKeys(database.bufferedResultSetQuery(
-                    connection -> connection.getMetaData().getPrimaryKeys(getCatalog(database), tableInfo.getNameSpace(), tableInfo.getName()),
-                    r -> new PrimaryKeyAttributesFromDb(streamName, r.getString(JDBC_COLUMN_COLUMN_NAME), r.getInt(KEY_SEQ))));
+                final Map<String, List<String>> primaryKeys = aggregatePrimateKeys(
+                    database.bufferedResultSetQuery(
+                        connection -> connection.getMetaData()
+                            .getPrimaryKeys(getCatalog(database), tableInfo.getNameSpace(),
+                                tableInfo.getName()),
+                        r -> new PrimaryKeyAttributesFromDb(streamName,
+                            r.getString(JDBC_COLUMN_COLUMN_NAME), r.getInt(KEY_SEQ))));
                 return primaryKeys.getOrDefault(streamName, Collections.emptyList());
               } catch (final SQLException e) {
-                LOGGER.error(String.format("Could not retrieve primary keys for %s: %s", streamName, e));
+                LOGGER.error(
+                    String.format("Could not retrieve primary keys for %s: %s", streamName, e));
                 return Collections.emptyList();
               }
             }));
@@ -357,13 +384,13 @@ public abstract class AbstractJdbcSource<Datatype> extends AbstractDbSource<Data
 
   @Override
   public AutoCloseableIterator<JsonNode> queryTableIncremental(final JdbcDatabase database,
-                                                               final List<String> columnNames,
-                                                               final String schemaName,
-                                                               final String tableName,
-                                                               final CursorInfo cursorInfo,
-                                                               final Datatype cursorFieldType,
-                                                               final String whereClause,
-                                                               final String customSQL) {
+      final List<String> columnNames,
+      final String schemaName,
+      final String tableName,
+      final CursorInfo cursorInfo,
+      final Datatype cursorFieldType,
+      final String whereClause,
+      final String customSQL) {
     LOGGER.info("Queueing query for table: {}", tableName);
     final io.airbyte.protocol.models.AirbyteStreamNameNamespacePair airbyteStream =
         AirbyteStreamUtils.convertFromNameAndNamespace(tableName, schemaName);
@@ -372,16 +399,20 @@ public abstract class AbstractJdbcSource<Datatype> extends AbstractDbSource<Data
         final Stream<JsonNode> stream = database.unsafeQuery(
             connection -> {
               LOGGER.info("Preparing query for table: {}", tableName);
-              final String fullTableName = getFullyQualifiedTableNameWithQuoting(schemaName, tableName, getQuoteString());
-              final String quotedCursorField = enquoteIdentifier(cursorInfo.getCursorField(), getQuoteString());
+              final String fullTableName = getFullyQualifiedTableNameWithQuoting(schemaName,
+                  tableName, getQuoteString());
+              final String quotedCursorField = enquoteIdentifier(cursorInfo.getCursorField(),
+                  getQuoteString());
 
               final String operator;
               if (cursorInfo.getCursorRecordCount() <= 0L) {
                 operator = ">";
               } else {
                 final long actualRecordCount = getActualCursorRecordCount(
-                    connection, fullTableName, quotedCursorField, cursorFieldType, cursorInfo.getCursor());
-                LOGGER.info("Table {} cursor count: expected {}, actual {}", tableName, cursorInfo.getCursorRecordCount(), actualRecordCount);
+                    connection, fullTableName, quotedCursorField, cursorFieldType,
+                    cursorInfo.getCursor());
+                LOGGER.info("Table {} cursor count: expected {}, actual {}", tableName,
+                    cursorInfo.getCursorRecordCount(), actualRecordCount);
                 if (actualRecordCount == cursorInfo.getCursorRecordCount()) {
                   operator = ">";
                 } else {
@@ -389,10 +420,13 @@ public abstract class AbstractJdbcSource<Datatype> extends AbstractDbSource<Data
                 }
               }
 
-              final String wrappedColumnNames = getWrappedColumnNames(database, connection, columnNames, schemaName, tableName);
+              final String wrappedColumnNames = getWrappedColumnNames(database, connection,
+                  columnNames, schemaName, tableName);
               StringBuilder sql = new StringBuilder();
-              if (customSQL!= null && !customSQL.equals("")) {
-                sql = new StringBuilder(String.format("SELECT * FROM (%s) sc WHERE %s %s ?", customSQL, quotedCursorField, operator));
+              if (customSQL != null && !customSQL.equals("")) {
+                sql = new StringBuilder(
+                    String.format("SELECT * FROM (%s) sc WHERE %s %s ?", customSQL,
+                        quotedCursorField, operator));
               } else {
                 sql = new StringBuilder(String.format("SELECT %s FROM %s WHERE %s %s ?",
                     wrappedColumnNames,
@@ -409,9 +443,11 @@ public abstract class AbstractJdbcSource<Datatype> extends AbstractDbSource<Data
                 sql.append(String.format(" ORDER BY %s ASC", quotedCursorField));
               }
 
-              final PreparedStatement preparedStatement = connection.prepareStatement(sql.toString());
+              final PreparedStatement preparedStatement = connection.prepareStatement(
+                  sql.toString());
               LOGGER.info("Executing query for table {}: {}", tableName, sql);
-              sourceOperations.setCursorField(preparedStatement, 1, cursorFieldType, cursorInfo.getCursor());
+              sourceOperations.setCursorField(preparedStatement, 1, cursorFieldType,
+                  cursorInfo.getCursor());
               return preparedStatement;
             },
             sourceOperations::rowToJson);
@@ -426,10 +462,10 @@ public abstract class AbstractJdbcSource<Datatype> extends AbstractDbSource<Data
    * Some databases need special column names in the query.
    */
   protected String getWrappedColumnNames(final JdbcDatabase database,
-                                         final Connection connection,
-                                         final List<String> columnNames,
-                                         final String schemaName,
-                                         final String tableName)
+      final Connection connection,
+      final List<String> columnNames,
+      final String schemaName,
+      final String tableName)
       throws SQLException {
     return enquoteIdentifierList(columnNames, getQuoteString());
   }
@@ -439,15 +475,16 @@ public abstract class AbstractJdbcSource<Datatype> extends AbstractDbSource<Data
   }
 
   protected long getActualCursorRecordCount(final Connection connection,
-                                            final String fullTableName,
-                                            final String quotedCursorField,
-                                            final Datatype cursorFieldType,
-                                            final String cursor)
+      final String fullTableName,
+      final String quotedCursorField,
+      final Datatype cursorFieldType,
+      final String cursor)
       throws SQLException {
     final String columnName = getCountColumnName();
     final PreparedStatement cursorRecordStatement;
     if (cursor == null) {
-      final String cursorRecordQuery = String.format("SELECT COUNT(*) AS %s FROM %s WHERE %s IS NULL",
+      final String cursorRecordQuery = String.format(
+          "SELECT COUNT(*) AS %s FROM %s WHERE %s IS NULL",
           columnName,
           fullTableName,
           quotedCursorField);
@@ -457,7 +494,8 @@ public abstract class AbstractJdbcSource<Datatype> extends AbstractDbSource<Data
           columnName,
           fullTableName,
           quotedCursorField);
-      cursorRecordStatement = connection.prepareStatement(cursorRecordQuery);;
+      cursorRecordStatement = connection.prepareStatement(cursorRecordQuery);
+      ;
       sourceOperations.setCursorField(cursorRecordStatement, 1, cursorFieldType, cursor);
     }
     final ResultSet resultSet = cursorRecordStatement.executeQuery();
@@ -473,13 +511,17 @@ public abstract class AbstractJdbcSource<Datatype> extends AbstractDbSource<Data
     return createDatabase(sourceConfig, JdbcDataSourceUtils.DEFAULT_JDBC_PARAMETERS_DELIMITER);
   }
 
-  public JdbcDatabase createDatabase(final JsonNode sourceConfig, String delimiter) throws SQLException {
+  public JdbcDatabase createDatabase(final JsonNode sourceConfig, String delimiter)
+      throws SQLException {
     final JsonNode jdbcConfig = toDatabaseConfig(sourceConfig);
-    Map<String, String> connectionProperties = JdbcDataSourceUtils.getConnectionProperties(sourceConfig, delimiter);
+    Map<String, String> connectionProperties = JdbcDataSourceUtils.getConnectionProperties(
+        sourceConfig, delimiter);
     // Create the data source
     final DataSource dataSource = DataSourceFactory.create(
-        jdbcConfig.has(JdbcUtils.USERNAME_KEY) ? jdbcConfig.get(JdbcUtils.USERNAME_KEY).asText() : null,
-        jdbcConfig.has(JdbcUtils.PASSWORD_KEY) ? jdbcConfig.get(JdbcUtils.PASSWORD_KEY).asText() : null,
+        jdbcConfig.has(JdbcUtils.USERNAME_KEY) ? jdbcConfig.get(JdbcUtils.USERNAME_KEY).asText()
+            : null,
+        jdbcConfig.has(JdbcUtils.PASSWORD_KEY) ? jdbcConfig.get(JdbcUtils.PASSWORD_KEY).asText()
+            : null,
         driverClassName,
         jdbcConfig.get(JdbcUtils.JDBC_URL_KEY).asText(),
         connectionProperties,
@@ -492,7 +534,8 @@ public abstract class AbstractJdbcSource<Datatype> extends AbstractDbSource<Data
         sourceOperations,
         streamingQueryConfigProvider);
 
-    quoteString = (quoteString == null ? database.getMetaData().getIdentifierQuoteString() : quoteString);
+    quoteString = (quoteString == null ? database.getMetaData().getIdentifierQuoteString()
+        : quoteString);
     database.setSourceConfig(sourceConfig);
     database.setDatabaseConfig(jdbcConfig);
     return database;
@@ -502,11 +545,12 @@ public abstract class AbstractJdbcSource<Datatype> extends AbstractDbSource<Data
    * {@inheritDoc}
    *
    * @param database database instance
-   * @param catalog schema of the incoming messages.
+   * @param catalog  schema of the incoming messages.
    * @throws SQLException
    */
   @Override
-  protected void logPreSyncDebugData(final JdbcDatabase database, final ConfiguredAirbyteCatalog catalog)
+  protected void logPreSyncDebugData(final JdbcDatabase database,
+      final ConfiguredAirbyteCatalog catalog)
       throws SQLException {
     LOGGER.info("Data source product recognized as {}:{}",
         database.getMetaData().getDatabaseProductName(),
@@ -525,20 +569,25 @@ public abstract class AbstractJdbcSource<Datatype> extends AbstractDbSource<Data
     dataSources.clear();
   }
 
-  protected List<ConfiguredAirbyteStream> identifyStreamsToSnapshot(final ConfiguredAirbyteCatalog catalog, final StateManager stateManager) {
-    final Set<AirbyteStreamNameNamespacePair> alreadySyncedStreams = stateManager.getCdcStateManager().getInitialStreamsSynced();
+  protected List<ConfiguredAirbyteStream> identifyStreamsToSnapshot(
+      final ConfiguredAirbyteCatalog catalog, final StateManager stateManager) {
+    final Set<AirbyteStreamNameNamespacePair> alreadySyncedStreams = stateManager.getCdcStateManager()
+        .getInitialStreamsSynced();
     if (alreadySyncedStreams.isEmpty() && (stateManager.getCdcStateManager().getCdcState() == null
         || stateManager.getCdcStateManager().getCdcState().getState() == null)) {
       return Collections.emptyList();
     }
 
-    final Set<AirbyteStreamNameNamespacePair> allStreams = AirbyteStreamNameNamespacePair.fromConfiguredCatalog(catalog);
+    final Set<AirbyteStreamNameNamespacePair> allStreams = AirbyteStreamNameNamespacePair.fromConfiguredCatalog(
+        catalog);
 
-    final Set<AirbyteStreamNameNamespacePair> newlyAddedStreams = new HashSet<>(Sets.difference(allStreams, alreadySyncedStreams));
+    final Set<AirbyteStreamNameNamespacePair> newlyAddedStreams = new HashSet<>(
+        Sets.difference(allStreams, alreadySyncedStreams));
 
     return catalog.getStreams().stream()
         .filter(c -> c.getSyncMode() == SyncMode.INCREMENTAL)
-        .filter(stream -> newlyAddedStreams.contains(AirbyteStreamNameNamespacePair.fromAirbyteStream(stream.getStream())))
+        .filter(stream -> newlyAddedStreams.contains(
+            AirbyteStreamNameNamespacePair.fromAirbyteStream(stream.getStream())))
         .map(Jsons::clone)
         .collect(Collectors.toList());
   }
@@ -617,6 +666,7 @@ public abstract class AbstractJdbcSource<Datatype> extends AbstractDbSource<Data
                     .put(INTERNAL_COLUMN_TYPE, metaData.getColumnType(i))
                     .put(INTERNAL_COLUMN_TYPE_NAME, metaData.getColumnTypeName(i))
                     .put(INTERNAL_COLUMN_SIZE, metaData.getColumnDisplaySize(i))
+                    .put(INTERNAL_DECIMAL_DIGITS, metaData.getScale(i))
                     .put(INTERNAL_IS_NULLABLE, metaData.isNullable(i)).build())
             );
             return new CommonField<>(columnName, datatype);

--- a/airbyte-cdk/java/airbyte-cdk/db-sources/src/main/java/io/airbyte/cdk/integrations/source/jdbc/AbstractJdbcSource.java
+++ b/airbyte-cdk/java/airbyte-cdk/db-sources/src/main/java/io/airbyte/cdk/integrations/source/jdbc/AbstractJdbcSource.java
@@ -91,8 +91,7 @@ import org.slf4j.LoggerFactory;
  * relational DB source which can be accessed via JDBC driver. If you are implementing a connector
  * for a relational DB which has a JDBC driver, make an effort to use this class.
  */
-public abstract class AbstractJdbcSource<Datatype> extends
-    AbstractDbSource<Datatype, JdbcDatabase> implements Source {
+public abstract class AbstractJdbcSource<Datatype> extends AbstractDbSource<Datatype, JdbcDatabase> implements Source {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(AbstractJdbcSource.class);
 
@@ -103,8 +102,8 @@ public abstract class AbstractJdbcSource<Datatype> extends
   protected Collection<DataSource> dataSources = new ArrayList<>();
 
   public AbstractJdbcSource(final String driverClass,
-      final Supplier<JdbcStreamingQueryConfig> streamingQueryConfigProvider,
-      final JdbcCompatibleSourceOperations<Datatype> sourceOperations) {
+                            final Supplier<JdbcStreamingQueryConfig> streamingQueryConfigProvider,
+                            final JdbcCompatibleSourceOperations<Datatype> sourceOperations) {
     super(driverClass);
     this.streamingQueryConfigProvider = streamingQueryConfigProvider;
     this.sourceOperations = sourceOperations;
@@ -126,15 +125,14 @@ public abstract class AbstractJdbcSource<Datatype> extends
     if (syncMode.equals(SyncMode.INCREMENTAL) && getStateEmissionFrequency() > 0) {
       final String quotedCursorField = enquoteIdentifier(cursorField.get(), getQuoteString());
       String query = "";
-      if (!whereClause.isEmpty()) {
+      if (!whereClause.equals("")) {
         query = String.format("SELECT %s FROM %s where %s ORDER BY %s ASC",
             enquoteIdentifierList(columnNames, getQuoteString()),
             getFullyQualifiedTableNameWithQuoting(schemaName, tableName, getQuoteString()),
             whereClause,
             quotedCursorField);
-      } else if (customSQL != null && !customSQL.isEmpty()) {
-        query = String.format("SELECT * FROM (%s) sc ORDER BY %s ASC", customSQL,
-            quotedCursorField);
+      } else if (customSQL != null && !customSQL.equals("")) {
+        query = String.format("SELECT * FROM (%s) sc ORDER BY %s ASC", customSQL, quotedCursorField);
       } else {
         query = String.format("SELECT %s FROM %s ORDER BY %s ASC",
             enquoteIdentifierList(columnNames, getQuoteString()),
@@ -171,12 +169,10 @@ public abstract class AbstractJdbcSource<Datatype> extends
    * @return list of consumers that run queries for the check command.
    */
   @Trace(operationName = CHECK_TRACE_OPERATION_NAME)
-  protected List<CheckedConsumer<JdbcDatabase, Exception>> getCheckOperations(final JsonNode config)
-      throws Exception {
+  protected List<CheckedConsumer<JdbcDatabase, Exception>> getCheckOperations(final JsonNode config) throws Exception {
     return ImmutableList.of(database -> {
       LOGGER.info("Attempting to get metadata from the database to see if we can connect.");
-      database.bufferedResultSetQuery(connection -> connection.getMetaData().getCatalogs(),
-          sourceOperations::rowToJson);
+      database.bufferedResultSetQuery(connection -> connection.getMetaData().getCatalogs(), sourceOperations::rowToJson);
     });
   }
 
@@ -186,42 +182,36 @@ public abstract class AbstractJdbcSource<Datatype> extends
    * @return a map by StreamName to associated list of primary keys
    */
   @VisibleForTesting
-  public static Map<String, List<String>> aggregatePrimateKeys(
-      final List<PrimaryKeyAttributesFromDb> entries) {
+  public static Map<String, List<String>> aggregatePrimateKeys(final List<PrimaryKeyAttributesFromDb> entries) {
     final Map<String, List<String>> result = new HashMap<>();
-    entries.stream().sorted(Comparator.comparingInt(PrimaryKeyAttributesFromDb::keySequence))
-        .forEach(entry -> {
-          if (!result.containsKey(entry.streamName())) {
-            result.put(entry.streamName(), new ArrayList<>());
-          }
-          result.get(entry.streamName()).add(entry.primaryKey());
-        });
+    entries.stream().sorted(Comparator.comparingInt(PrimaryKeyAttributesFromDb::keySequence)).forEach(entry -> {
+      if (!result.containsKey(entry.streamName())) {
+        result.put(entry.streamName(), new ArrayList<>());
+      }
+      result.get(entry.streamName()).add(entry.primaryKey());
+    });
     return result;
   }
 
   private String getCatalog(final SqlDatabase database) {
-    return (database.getSourceConfig().has(JdbcUtils.DATABASE_KEY) ? database.getSourceConfig()
-        .get(JdbcUtils.DATABASE_KEY).asText() : null);
+    return (database.getSourceConfig().has(JdbcUtils.DATABASE_KEY) ? database.getSourceConfig().get(JdbcUtils.DATABASE_KEY).asText() : null);
   }
 
   @Override
-  protected List<TableInfo<CommonField<Datatype>>> discoverInternal(final JdbcDatabase database,
-      final String schema) throws Exception {
+  protected List<TableInfo<CommonField<Datatype>>> discoverInternal(final JdbcDatabase database, final String schema) throws Exception {
     final Set<String> internalSchemas = new HashSet<>(getExcludedInternalNameSpaces());
     LOGGER.info("Internal schemas to exclude: {}", internalSchemas);
-    final Set<JdbcPrivilegeDto> tablesWithSelectGrantPrivilege = getPrivilegesTableForCurrentUser(
-        database, schema);
+    final Set<JdbcPrivilegeDto> tablesWithSelectGrantPrivilege = getPrivilegesTableForCurrentUser(database, schema);
     return database.bufferedResultSetQuery(
-            // retrieve column metadata from the database
-            connection -> connection.getMetaData().getColumns(getCatalog(database), schema, null, null),
-            // store essential column metadata to a Json object from the result set about each column
-            this::getColumnMetadata)
+        // retrieve column metadata from the database
+        connection -> connection.getMetaData().getColumns(getCatalog(database), schema, null, null),
+        // store essential column metadata to a Json object from the result set about each column
+        this::getColumnMetadata)
         .stream()
         .filter(excludeNotAccessibleTables(internalSchemas, tablesWithSelectGrantPrivilege))
         // group by schema and table name to handle the case where a table with the same name exists in
         // multiple schemas.
-        .collect(Collectors.groupingBy(t -> ImmutablePair.of(t.get(INTERNAL_SCHEMA_NAME).asText(),
-            t.get(INTERNAL_TABLE_NAME).asText())))
+        .collect(Collectors.groupingBy(t -> ImmutablePair.of(t.get(INTERNAL_SCHEMA_NAME).asText(), t.get(INTERNAL_TABLE_NAME).asText())))
         .values()
         .stream()
         .map(fields -> TableInfo.<CommonField<Datatype>>builder()
@@ -239,8 +229,7 @@ public abstract class AbstractJdbcSource<Datatype> extends
                       f.get(INTERNAL_COLUMN_SIZE).asInt(),
                       f.get(INTERNAL_IS_NULLABLE).asBoolean(),
                       jsonType);
-                  return new CommonField<Datatype>(f.get(INTERNAL_COLUMN_NAME).asText(), datatype) {
-                  };
+                  return new CommonField<Datatype>(f.get(INTERNAL_COLUMN_NAME).asText(), datatype) {};
                 })
                 .collect(Collectors.toList()))
             .cursorFields(extractCursorFields(fields))
@@ -256,7 +245,7 @@ public abstract class AbstractJdbcSource<Datatype> extends
   }
 
   protected Predicate<JsonNode> excludeNotAccessibleTables(final Set<String> internalSchemas,
-      final Set<JdbcPrivilegeDto> tablesWithSelectGrantPrivilege) {
+                                                           final Set<JdbcPrivilegeDto> tablesWithSelectGrantPrivilege) {
     return jsonNode -> {
       if (tablesWithSelectGrantPrivilege.isEmpty()) {
         return isNotInternalSchema(jsonNode, internalSchemas);
@@ -264,29 +253,26 @@ public abstract class AbstractJdbcSource<Datatype> extends
       return tablesWithSelectGrantPrivilege.stream()
           .anyMatch(e -> e.getSchemaName().equals(jsonNode.get(INTERNAL_SCHEMA_NAME).asText()))
           && tablesWithSelectGrantPrivilege.stream()
-          .anyMatch(e -> e.getTableName().equals(jsonNode.get(INTERNAL_TABLE_NAME).asText()))
+              .anyMatch(e -> e.getTableName().equals(jsonNode.get(INTERNAL_TABLE_NAME).asText()))
           && !internalSchemas.contains(jsonNode.get(INTERNAL_SCHEMA_NAME).asText());
     };
   }
 
   // needs to override isNotInternalSchema for connectors that override
   // getPrivilegesTableForCurrentUser()
-  protected boolean isNotInternalSchema(final JsonNode jsonNode,
-      final Set<String> internalSchemas) {
+  protected boolean isNotInternalSchema(final JsonNode jsonNode, final Set<String> internalSchemas) {
     return !internalSchemas.contains(jsonNode.get(INTERNAL_SCHEMA_NAME).asText());
   }
 
   /**
    * @param resultSet Description of a column available in the table catalog.
-   * @return Essential information about a column to determine which table it belongs to and its
-   * type.
+   * @return Essential information about a column to determine which table it belongs to and its type.
    */
   private JsonNode getColumnMetadata(final ResultSet resultSet) throws SQLException {
     final var fieldMap = ImmutableMap.<String, Object>builder()
         // we always want a namespace, if we cannot get a schema, use db name.
         .put(INTERNAL_SCHEMA_NAME,
-            resultSet.getObject(JDBC_COLUMN_SCHEMA_NAME) != null ? resultSet.getString(
-                JDBC_COLUMN_SCHEMA_NAME)
+            resultSet.getObject(JDBC_COLUMN_SCHEMA_NAME) != null ? resultSet.getString(JDBC_COLUMN_SCHEMA_NAME)
                 : resultSet.getObject(JDBC_COLUMN_DATABASE_NAME))
         .put(INTERNAL_TABLE_NAME, resultSet.getString(JDBC_COLUMN_TABLE_NAME))
         .put(INTERNAL_COLUMN_NAME, resultSet.getString(JDBC_COLUMN_COLUMN_NAME))
@@ -320,53 +306,40 @@ public abstract class AbstractJdbcSource<Datatype> extends
 
   @Override
   protected Map<String, List<String>> discoverPrimaryKeys(final JdbcDatabase database,
-      final List<TableInfo<CommonField<Datatype>>> tableInfos) {
-    LOGGER.info(
-        "Discover primary keys for tables: " + tableInfos.stream().map(TableInfo::getName).collect(
-            Collectors.toSet()));
+                                                          final List<TableInfo<CommonField<Datatype>>> tableInfos) {
+    LOGGER.info("Discover primary keys for tables: " + tableInfos.stream().map(TableInfo::getName).collect(
+        Collectors.toSet()));
     try {
       // Get all primary keys without specifying a table name
-      final Map<String, List<String>> tablePrimaryKeys = aggregatePrimateKeys(
-          database.bufferedResultSetQuery(
-              connection -> connection.getMetaData()
-                  .getPrimaryKeys(getCatalog(database), null, null),
-              r -> {
-                final String schemaName =
-                    r.getObject(JDBC_COLUMN_SCHEMA_NAME) != null ? r.getString(
-                        JDBC_COLUMN_SCHEMA_NAME) : r.getString(JDBC_COLUMN_DATABASE_NAME);
-                final String streamName = JdbcUtils.getFullyQualifiedTableName(schemaName,
-                    r.getString(JDBC_COLUMN_TABLE_NAME));
-                final String primaryKey = r.getString(JDBC_COLUMN_COLUMN_NAME);
-                final int keySeq = r.getInt(KEY_SEQ);
-                return new PrimaryKeyAttributesFromDb(streamName, primaryKey, keySeq);
-              }));
+      final Map<String, List<String>> tablePrimaryKeys = aggregatePrimateKeys(database.bufferedResultSetQuery(
+          connection -> connection.getMetaData().getPrimaryKeys(getCatalog(database), null, null),
+          r -> {
+            final String schemaName =
+                r.getObject(JDBC_COLUMN_SCHEMA_NAME) != null ? r.getString(JDBC_COLUMN_SCHEMA_NAME) : r.getString(JDBC_COLUMN_DATABASE_NAME);
+            final String streamName = JdbcUtils.getFullyQualifiedTableName(schemaName, r.getString(JDBC_COLUMN_TABLE_NAME));
+            final String primaryKey = r.getString(JDBC_COLUMN_COLUMN_NAME);
+            final int keySeq = r.getInt(KEY_SEQ);
+            return new PrimaryKeyAttributesFromDb(streamName, primaryKey, keySeq);
+          }));
       if (!tablePrimaryKeys.isEmpty()) {
         return tablePrimaryKeys;
       }
     } catch (final SQLException e) {
-      LOGGER.debug(
-          String.format("Could not retrieve primary keys without a table name (%s), retrying", e));
+      LOGGER.debug(String.format("Could not retrieve primary keys without a table name (%s), retrying", e));
     }
     // Get primary keys one table at a time
     return tableInfos.stream()
         .collect(Collectors.toMap(
-            tableInfo -> JdbcUtils.getFullyQualifiedTableName(tableInfo.getNameSpace(),
-                tableInfo.getName()),
+            tableInfo -> JdbcUtils.getFullyQualifiedTableName(tableInfo.getNameSpace(), tableInfo.getName()),
             tableInfo -> {
-              final String streamName = JdbcUtils.getFullyQualifiedTableName(
-                  tableInfo.getNameSpace(), tableInfo.getName());
+              final String streamName = JdbcUtils.getFullyQualifiedTableName(tableInfo.getNameSpace(), tableInfo.getName());
               try {
-                final Map<String, List<String>> primaryKeys = aggregatePrimateKeys(
-                    database.bufferedResultSetQuery(
-                        connection -> connection.getMetaData()
-                            .getPrimaryKeys(getCatalog(database), tableInfo.getNameSpace(),
-                                tableInfo.getName()),
-                        r -> new PrimaryKeyAttributesFromDb(streamName,
-                            r.getString(JDBC_COLUMN_COLUMN_NAME), r.getInt(KEY_SEQ))));
+                final Map<String, List<String>> primaryKeys = aggregatePrimateKeys(database.bufferedResultSetQuery(
+                    connection -> connection.getMetaData().getPrimaryKeys(getCatalog(database), tableInfo.getNameSpace(), tableInfo.getName()),
+                    r -> new PrimaryKeyAttributesFromDb(streamName, r.getString(JDBC_COLUMN_COLUMN_NAME), r.getInt(KEY_SEQ))));
                 return primaryKeys.getOrDefault(streamName, Collections.emptyList());
               } catch (final SQLException e) {
-                LOGGER.error(
-                    String.format("Could not retrieve primary keys for %s: %s", streamName, e));
+                LOGGER.error(String.format("Could not retrieve primary keys for %s: %s", streamName, e));
                 return Collections.emptyList();
               }
             }));
@@ -384,13 +357,13 @@ public abstract class AbstractJdbcSource<Datatype> extends
 
   @Override
   public AutoCloseableIterator<JsonNode> queryTableIncremental(final JdbcDatabase database,
-      final List<String> columnNames,
-      final String schemaName,
-      final String tableName,
-      final CursorInfo cursorInfo,
-      final Datatype cursorFieldType,
-      final String whereClause,
-      final String customSQL) {
+                                                               final List<String> columnNames,
+                                                               final String schemaName,
+                                                               final String tableName,
+                                                               final CursorInfo cursorInfo,
+                                                               final Datatype cursorFieldType,
+                                                               final String whereClause,
+                                                               final String customSQL) {
     LOGGER.info("Queueing query for table: {}", tableName);
     final io.airbyte.protocol.models.AirbyteStreamNameNamespacePair airbyteStream =
         AirbyteStreamUtils.convertFromNameAndNamespace(tableName, schemaName);
@@ -399,20 +372,16 @@ public abstract class AbstractJdbcSource<Datatype> extends
         final Stream<JsonNode> stream = database.unsafeQuery(
             connection -> {
               LOGGER.info("Preparing query for table: {}", tableName);
-              final String fullTableName = getFullyQualifiedTableNameWithQuoting(schemaName,
-                  tableName, getQuoteString());
-              final String quotedCursorField = enquoteIdentifier(cursorInfo.getCursorField(),
-                  getQuoteString());
+              final String fullTableName = getFullyQualifiedTableNameWithQuoting(schemaName, tableName, getQuoteString());
+              final String quotedCursorField = enquoteIdentifier(cursorInfo.getCursorField(), getQuoteString());
 
               final String operator;
               if (cursorInfo.getCursorRecordCount() <= 0L) {
                 operator = ">";
               } else {
                 final long actualRecordCount = getActualCursorRecordCount(
-                    connection, fullTableName, quotedCursorField, cursorFieldType,
-                    cursorInfo.getCursor());
-                LOGGER.info("Table {} cursor count: expected {}, actual {}", tableName,
-                    cursorInfo.getCursorRecordCount(), actualRecordCount);
+                    connection, fullTableName, quotedCursorField, cursorFieldType, cursorInfo.getCursor());
+                LOGGER.info("Table {} cursor count: expected {}, actual {}", tableName, cursorInfo.getCursorRecordCount(), actualRecordCount);
                 if (actualRecordCount == cursorInfo.getCursorRecordCount()) {
                   operator = ">";
                 } else {
@@ -420,13 +389,10 @@ public abstract class AbstractJdbcSource<Datatype> extends
                 }
               }
 
-              final String wrappedColumnNames = getWrappedColumnNames(database, connection,
-                  columnNames, schemaName, tableName);
+              final String wrappedColumnNames = getWrappedColumnNames(database, connection, columnNames, schemaName, tableName);
               StringBuilder sql = new StringBuilder();
-              if (customSQL != null && !customSQL.equals("")) {
-                sql = new StringBuilder(
-                    String.format("SELECT * FROM (%s) sc WHERE %s %s ?", customSQL,
-                        quotedCursorField, operator));
+              if (customSQL!= null && !customSQL.equals("")) {
+                sql = new StringBuilder(String.format("SELECT * FROM (%s) sc WHERE %s %s ?", customSQL, quotedCursorField, operator));
               } else {
                 sql = new StringBuilder(String.format("SELECT %s FROM %s WHERE %s %s ?",
                     wrappedColumnNames,
@@ -443,11 +409,9 @@ public abstract class AbstractJdbcSource<Datatype> extends
                 sql.append(String.format(" ORDER BY %s ASC", quotedCursorField));
               }
 
-              final PreparedStatement preparedStatement = connection.prepareStatement(
-                  sql.toString());
+              final PreparedStatement preparedStatement = connection.prepareStatement(sql.toString());
               LOGGER.info("Executing query for table {}: {}", tableName, sql);
-              sourceOperations.setCursorField(preparedStatement, 1, cursorFieldType,
-                  cursorInfo.getCursor());
+              sourceOperations.setCursorField(preparedStatement, 1, cursorFieldType, cursorInfo.getCursor());
               return preparedStatement;
             },
             sourceOperations::rowToJson);
@@ -462,10 +426,10 @@ public abstract class AbstractJdbcSource<Datatype> extends
    * Some databases need special column names in the query.
    */
   protected String getWrappedColumnNames(final JdbcDatabase database,
-      final Connection connection,
-      final List<String> columnNames,
-      final String schemaName,
-      final String tableName)
+                                         final Connection connection,
+                                         final List<String> columnNames,
+                                         final String schemaName,
+                                         final String tableName)
       throws SQLException {
     return enquoteIdentifierList(columnNames, getQuoteString());
   }
@@ -475,16 +439,15 @@ public abstract class AbstractJdbcSource<Datatype> extends
   }
 
   protected long getActualCursorRecordCount(final Connection connection,
-      final String fullTableName,
-      final String quotedCursorField,
-      final Datatype cursorFieldType,
-      final String cursor)
+                                            final String fullTableName,
+                                            final String quotedCursorField,
+                                            final Datatype cursorFieldType,
+                                            final String cursor)
       throws SQLException {
     final String columnName = getCountColumnName();
     final PreparedStatement cursorRecordStatement;
     if (cursor == null) {
-      final String cursorRecordQuery = String.format(
-          "SELECT COUNT(*) AS %s FROM %s WHERE %s IS NULL",
+      final String cursorRecordQuery = String.format("SELECT COUNT(*) AS %s FROM %s WHERE %s IS NULL",
           columnName,
           fullTableName,
           quotedCursorField);
@@ -494,8 +457,7 @@ public abstract class AbstractJdbcSource<Datatype> extends
           columnName,
           fullTableName,
           quotedCursorField);
-      cursorRecordStatement = connection.prepareStatement(cursorRecordQuery);
-      ;
+      cursorRecordStatement = connection.prepareStatement(cursorRecordQuery);;
       sourceOperations.setCursorField(cursorRecordStatement, 1, cursorFieldType, cursor);
     }
     final ResultSet resultSet = cursorRecordStatement.executeQuery();
@@ -511,17 +473,13 @@ public abstract class AbstractJdbcSource<Datatype> extends
     return createDatabase(sourceConfig, JdbcDataSourceUtils.DEFAULT_JDBC_PARAMETERS_DELIMITER);
   }
 
-  public JdbcDatabase createDatabase(final JsonNode sourceConfig, String delimiter)
-      throws SQLException {
+  public JdbcDatabase createDatabase(final JsonNode sourceConfig, String delimiter) throws SQLException {
     final JsonNode jdbcConfig = toDatabaseConfig(sourceConfig);
-    Map<String, String> connectionProperties = JdbcDataSourceUtils.getConnectionProperties(
-        sourceConfig, delimiter);
+    Map<String, String> connectionProperties = JdbcDataSourceUtils.getConnectionProperties(sourceConfig, delimiter);
     // Create the data source
     final DataSource dataSource = DataSourceFactory.create(
-        jdbcConfig.has(JdbcUtils.USERNAME_KEY) ? jdbcConfig.get(JdbcUtils.USERNAME_KEY).asText()
-            : null,
-        jdbcConfig.has(JdbcUtils.PASSWORD_KEY) ? jdbcConfig.get(JdbcUtils.PASSWORD_KEY).asText()
-            : null,
+        jdbcConfig.has(JdbcUtils.USERNAME_KEY) ? jdbcConfig.get(JdbcUtils.USERNAME_KEY).asText() : null,
+        jdbcConfig.has(JdbcUtils.PASSWORD_KEY) ? jdbcConfig.get(JdbcUtils.PASSWORD_KEY).asText() : null,
         driverClassName,
         jdbcConfig.get(JdbcUtils.JDBC_URL_KEY).asText(),
         connectionProperties,
@@ -534,8 +492,7 @@ public abstract class AbstractJdbcSource<Datatype> extends
         sourceOperations,
         streamingQueryConfigProvider);
 
-    quoteString = (quoteString == null ? database.getMetaData().getIdentifierQuoteString()
-        : quoteString);
+    quoteString = (quoteString == null ? database.getMetaData().getIdentifierQuoteString() : quoteString);
     database.setSourceConfig(sourceConfig);
     database.setDatabaseConfig(jdbcConfig);
     return database;
@@ -545,12 +502,11 @@ public abstract class AbstractJdbcSource<Datatype> extends
    * {@inheritDoc}
    *
    * @param database database instance
-   * @param catalog  schema of the incoming messages.
+   * @param catalog schema of the incoming messages.
    * @throws SQLException
    */
   @Override
-  protected void logPreSyncDebugData(final JdbcDatabase database,
-      final ConfiguredAirbyteCatalog catalog)
+  protected void logPreSyncDebugData(final JdbcDatabase database, final ConfiguredAirbyteCatalog catalog)
       throws SQLException {
     LOGGER.info("Data source product recognized as {}:{}",
         database.getMetaData().getDatabaseProductName(),
@@ -569,25 +525,20 @@ public abstract class AbstractJdbcSource<Datatype> extends
     dataSources.clear();
   }
 
-  protected List<ConfiguredAirbyteStream> identifyStreamsToSnapshot(
-      final ConfiguredAirbyteCatalog catalog, final StateManager stateManager) {
-    final Set<AirbyteStreamNameNamespacePair> alreadySyncedStreams = stateManager.getCdcStateManager()
-        .getInitialStreamsSynced();
+  protected List<ConfiguredAirbyteStream> identifyStreamsToSnapshot(final ConfiguredAirbyteCatalog catalog, final StateManager stateManager) {
+    final Set<AirbyteStreamNameNamespacePair> alreadySyncedStreams = stateManager.getCdcStateManager().getInitialStreamsSynced();
     if (alreadySyncedStreams.isEmpty() && (stateManager.getCdcStateManager().getCdcState() == null
         || stateManager.getCdcStateManager().getCdcState().getState() == null)) {
       return Collections.emptyList();
     }
 
-    final Set<AirbyteStreamNameNamespacePair> allStreams = AirbyteStreamNameNamespacePair.fromConfiguredCatalog(
-        catalog);
+    final Set<AirbyteStreamNameNamespacePair> allStreams = AirbyteStreamNameNamespacePair.fromConfiguredCatalog(catalog);
 
-    final Set<AirbyteStreamNameNamespacePair> newlyAddedStreams = new HashSet<>(
-        Sets.difference(allStreams, alreadySyncedStreams));
+    final Set<AirbyteStreamNameNamespacePair> newlyAddedStreams = new HashSet<>(Sets.difference(allStreams, alreadySyncedStreams));
 
     return catalog.getStreams().stream()
         .filter(c -> c.getSyncMode() == SyncMode.INCREMENTAL)
-        .filter(stream -> newlyAddedStreams.contains(
-            AirbyteStreamNameNamespacePair.fromAirbyteStream(stream.getStream())))
+        .filter(stream -> newlyAddedStreams.contains(AirbyteStreamNameNamespacePair.fromAirbyteStream(stream.getStream())))
         .map(Jsons::clone)
         .collect(Collectors.toList());
   }

--- a/airbyte-integrations/connectors/source-oracle/metadata.yaml
+++ b/airbyte-integrations/connectors/source-oracle/metadata.yaml
@@ -9,7 +9,7 @@ data:
   connectorSubtype: database
   connectorType: source
   definitionId: b39a7370-74c3-45a6-ac3a-380d48520a83
-  dockerImageTag: 0.5.2-v1.0.4
+  dockerImageTag: 0.5.2-v1.0.5
   dockerRepository: datapipes-airbyte/source-oracle
   documentationUrl: https://docs.airbyte.com/integrations/sources/oracle
   githubIssueLabel: source-oracle


### PR DESCRIPTION
<!--
Thanks for your contribution! 
Before you submit the pull request, 
I'd like to kindly remind you to take a moment and read through our guidelines
to ensure that your contribution aligns with the type of contributions our project accepts.
All the information you need can be found here:
   https://docs.airbyte.com/contributing-to-airbyte/

We truly appreciate your interest in contributing to Airbyte,
and we're excited to see what you have to offer! 

If you have any questions or need any assistance, feel free to reach out in #contributions Slack channel.
-->

## What
*Describe what the change is solving*
*It helps to add screenshots if it affects the frontend.*

## How
*Describe the solution*

## Recommended reading order
1. `x.java`
2. `y.python`

## 🚨 User Impact 🚨
*Are there any breaking changes? What is the end result perceived by the user?*

*For connector PRs, use this section to explain which type of semantic versioning bump occurs as a result of the changes. Refer to our [Semantic Versioning for Connectors](https://docs.airbyte.com/contributing-to-airbyte/#semantic-versioning-for-connectors) guidelines for more information. **Breaking changes to connectors must be documented by an Airbyte engineer (PR author, or reviewer for community PRs) by using the [Breaking Change Release Playbook](https://docs.google.com/document/d/1VYQggHbL_PN0dDDu7rCyzBLGRtX-R3cpwXaY8QxEgzw/edit).***

*If there are breaking changes, please merge this PR with the 🚨🚨 emoji so changelog authors can further highlight this if needed.*


## Pre-merge Actions
*Expand the relevant checklist and delete the others.*

<details><summary><strong>New Connector</strong></summary>

### Community member or Airbyter

- **Community member?** Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- Connector version is set to `0.0.1`
    - `Dockerfile` has version `0.0.1`
- Documentation updated
    - Connector's `README.md`
    - Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - `docs/integrations/<source or destination>/<name>.md` including changelog with an entry for the initial version. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
    - `docs/integrations/README.md`

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- Create a non-forked branch based on this PR and test the below items on it
- Build is successful
- If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).

</details>

<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- Unit & integration tests added


### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- Create a non-forked branch based on this PR and test the below items on it
- Build is successful
- If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).

</details>

<details><summary><strong>Connector Generator</strong></summary>

- Issue acceptance criteria met
- PR name follows [PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/resources/pull-requests-handbook)
- If adding a new generator, add it to the [list of scaffold modules being tested](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connector-templates/generator/build.gradle#L41)
- The generator test modules (all connectors with `-scaffold` in their name) have been updated with the latest scaffold by running `./gradlew :airbyte-integrations:connector-templates:generator:generateScaffolds` then checking in your changes
- Documentation which references the generator is updated as needed

</details>

<details><summary><strong>Updating the Python CDK</strong></summary>

### Airbyter

Before merging:
- Pull Request description explains what problem it is solving
- Code change is unit tested
- Build and my-py check pass
- Smoke test the change on at least one affected connector
   - On Github: Run [this workflow](https://github.com/airbytehq/airbyte/actions/workflows/connectors_tests.yml), passing `--use-local-cdk --name=source-<connector>` as options
   - Locally: `airbyte-ci connectors --use-local-cdk --name=source-<connector> test`
- PR is reviewed and approved
      
After merging:
- [Publish the CDK](https://github.com/airbytehq/airbyte/actions/workflows/publish-cdk-command-manually.yml)
   - The CDK does not follow proper semantic versioning. Choose minor if this the change has significant user impact or is a breaking change. Choose patch otherwise.
   - Write a thoughtful changelog message so we know what was updated.
- Merge the platform PR that was auto-created for updating the Connector Builder's CDK version
   - This step is optional if the change does not affect the connector builder or declarative connectors.

</details>
